### PR TITLE
Test port integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"dm": "nodemon src/mask.js dm",
 		"lint": "eslint . --config .eslintrc.json --ext .js",
 		"start": "node src/mask.js",
-		"test": "npm run lint && npx mocha --timeout 3000 && echo \"Passing all tests.\" && exit 0",
+		"test": "npm run lint && npx mocha test --timeout 3000 && echo \"Passing all tests.\" && exit 0",
 		"prepare": "husky install"
 	},
 	"repository": {

--- a/src/config.js
+++ b/src/config.js
@@ -1,1 +1,5 @@
 exports.PORT = 6969;
+// check for dev flag and set port to 42069
+if (!process.argv.includes('dev')) {
+	exports.PORT = 42069;
+}

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,1 @@
 exports.PORT = 6969;
-// check for dev flag and set port to 42069
-if (!process.argv.includes('dev')) {
-	exports.PORT = 42069;
-}

--- a/src/env.js
+++ b/src/env.js
@@ -9,7 +9,7 @@ const aliases = {
 	m: 'mongoless',
 	q: 'quiz'
 };
-const validParams = ['dev', 'local', 'prod', 'mongoless', 'userless', 'quiz'];
+const validParams = ['dev', 'local', 'prod', 'mongoless', 'userless', 'quiz', 'test'];
 if (!global.PARAMS) {
 	if (process.env['NODE_ENV'] === 'production') process.env.prod = true;
 	const shorts = new Set();
@@ -53,4 +53,5 @@ exports.init = () => {
 	}
 	if (!PARAMS.prod) process.env.MONGO_URL = process.env.MONGO_TEST_URL;
 	if (PARAMS.local) process.env.MONGO_URL = 'mongodb://127.0.0.1/mask';
+	if (PARAMS.test) PARAMS.port = 42069;
 };

--- a/src/mask.js
+++ b/src/mask.js
@@ -9,7 +9,7 @@ const path = require('path');
 
 global.Tools = require('./tools.js');
 const DB = require('../database/database.js');
-const { PORT } = require('./config.js');
+const PORT =  PARAMS.port ?? require('./config.js').PORT;
 const appHandler = require('./handler.js');
 const socketio = require('socket.io')();
 const initMiddleware = require('./middleware.js');

--- a/test/site.js
+++ b/test/site.js
@@ -9,7 +9,7 @@ before(() => server.ready());
 
 describe('Server', () => {
 	pages.forEach(page => {
-		it(`should serve page (${page || '/'})`, () => axios.get(`http://localhost:${PORT}/${page}`)).timeout(1_000);
+		it(`should serve page (${page || '/'})`, () => axios.get(`http://localhost:${PORT}/${page}`)).timeout(1_500);
 		// Pages should render in under a second
 	});
 

--- a/test/site.js
+++ b/test/site.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const axios = require('axios');
 const server = require('../src/mask.js');
-const { PORT } = require('../src/config.js');
+const PORT = 42069;
 
 const pages = ['', 'home', 'art', 'videos', 'events', 'about', 'members', 'submissions'];
 


### PR DESCRIPTION
Runs `npm test` in port 42069 instead of 6969. Generally useful when people use GitHub Desktop or push commits while having an instance of the server running on another terminal or shell